### PR TITLE
Tweak to fix zero length nested arrays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splink_data_standardisation"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = ["Robin Linacre <robin.linacre@digital.justice.gov.uk>"]
 license = "MIT"

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -11,12 +11,12 @@ from pyspark.sql import Row
 def test_fix_1(spark):
 
     names_list = [
-        {"id": 1, "my_arr1": ["a", "b", "c"], "other_arr": [], "my_str": "a"},
-        {"id": 2, "my_arr1": [], "other_arr": [1], "my_str": "a"},
-        {"id": 3, "my_arr1": [None, "", "c"], "other_arr": [1], "my_str": "a"},
-        {"id": 4, "my_arr1": [None, ""], "other_arr": [1], "my_str": "a"},
-        {"id": 5, "my_arr1": [""], "other_arr": [1], "my_str": "a"},
-        {"id": 6, "my_arr1": [None, None], "other_arr": [1], "my_str": "a"},
+        {"id": 1, "my_arr1": ["a", "b", "c"], "other_arr": [], "my_str": "a", "arr_arr":[[1, 2], [3, 4]]},
+        {"id": 2, "my_arr1": [], "other_arr": [1], "my_str": "a", "arr_arr":[None, None]},
+        {"id": 3, "my_arr1": [None, "", "c"], "other_arr": [1], "my_str": "a", "arr_arr":[None, None]},
+        {"id": 4, "my_arr1": [None, ""], "other_arr": [1], "my_str": "a", "arr_arr":[]},
+        {"id": 5, "my_arr1": [""], "other_arr": [1], "my_str": "a", "arr_arr":[[1, 2], None]},
+        {"id": 6, "my_arr1": [None, None], "other_arr": [1], "my_str": "a", "arr_arr":[None, [3, 4]]},
     ]
 
     df = spark.createDataFrame(Row(**x) for x in names_list)
@@ -26,12 +26,12 @@ def test_fix_1(spark):
     df_result = df.toPandas()
 
     df_expected = [
-        {"id": 1, "my_arr1": ["a", "b", "c"], "other_arr": None, "my_str": "a"},
-        {"id": 2, "my_arr1": None, "other_arr": [1], "my_str": "a"},
-        {"id": 3, "my_arr1": ["c"], "other_arr": [1], "my_str": "a"},
-        {"id": 4, "my_arr1": None, "other_arr": [1], "my_str": "a"},
-        {"id": 5, "my_arr1": None, "other_arr": [1], "my_str": "a"},
-        {"id": 6, "my_arr1": None, "other_arr": [1], "my_str": "a"},
+        {"id": 1, "my_arr1": ["a", "b", "c"], "other_arr": None, "my_str": "a", "arr_arr": [[1, 2], [3, 4]]},
+        {"id": 2, "my_arr1": None, "other_arr": [1], "my_str": "a", "arr_arr": None},
+        {"id": 3, "my_arr1": ["c"], "other_arr": [1], "my_str": "a", "arr_arr": None},
+        {"id": 4, "my_arr1": None, "other_arr": [1], "my_str": "a", "arr_arr": None},
+        {"id": 5, "my_arr1": None, "other_arr": [1], "my_str": "a", "arr_arr": [[1, 2]]},
+        {"id": 6, "my_arr1": None, "other_arr": [1], "my_str": "a", "arr_arr": [[3, 4]]},
     ]
 
     df_expected = pd.DataFrame(df_expected)


### PR DESCRIPTION
`fix_zero_length_arrays` fails on nested array columns (e.g. array of lat/long), due to the use of `trim` in `fix_zero_length_array`:

```
cannot resolve 'trim(namedlambdavariable())' due to data type mismatch: argument 1 requires string type, however, 'namedlambdavariable()' is of array<double> type
```

By making the trim expression optional (but on by default so it won't break existing code) it can be run differently on nested arrays. 

This will remove null array elements and empty arrays, **but not empty array elements** because that would require more significant changes here. It's easy enough to prevent e.g. `lat_long = []` so `arr_lat_long` only contains nulls or valid arrays, but otherwise let `fix_zero_length_arrays` do all the work. 