### PR TITLE
fix arr bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splink_data_standardisation"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = ["Robin Linacre <robin.linacre@digital.justice.gov.uk>"]
 license = "MIT"

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -7,14 +7,16 @@ from pyspark.sql import Row
 
 def test_fix_1(spark):
 
+    # fmt: off
     names_list = [
-        {"id": 1, "my_arr1": ["a", "b", "c"], "other_arr": [ ],"my_str": "a"},
-        {"id": 2, "my_arr1": [             ], "other_arr": [1],"my_str": "a"},
-        {"id": 3, "my_arr1": [None, '', 'c'], "other_arr": [1],"my_str": "a"},
-        {"id": 4, "my_arr1": [None, ''     ], "other_arr": [1],"my_str": "a"},
-        {"id": 5, "my_arr1": [''           ], "other_arr": [1],"my_str": "a"},
-        {"id": 6, "my_arr1": [None, None   ], "other_arr": [1],"my_str": "a"},
+        {"id": 1, "my_arr1": ["a", "b", "c"], "other_arr": [ ],"my_str": "a", "complex_arr": [[1], [1]]},
+        {"id": 2, "my_arr1": [             ], "other_arr": [1],"my_str": "a", "complex_arr": []},
+        {"id": 3, "my_arr1": [None, '', 'c'], "other_arr": [1],"my_str": "a", "complex_arr": None},
+        {"id": 4, "my_arr1": [None, ''     ], "other_arr": [1],"my_str": "a", "complex_arr": [[1]]},
+        {"id": 5, "my_arr1": [''           ], "other_arr": [1],"my_str": "a", "complex_arr": [[1],[1]]},
+        {"id": 6, "my_arr1": [None, None   ], "other_arr": [1],"my_str": "a", "complex_arr": [[1],[1]]},
         ]
+    # fmt: on
 
     df = spark.createDataFrame(Row(**x) for x in names_list)
     df = df.select(list(names_list[0].keys()))
@@ -22,17 +24,18 @@ def test_fix_1(spark):
 
     df_result = df.toPandas()
 
+    # fmt: off
     df_expected = [
-        {"id": 1, "my_arr1": ["a", "b", "c"], "other_arr": None,"my_str": "a"},
-        {"id": 2, "my_arr1": None,            "other_arr": [1] ,"my_str": "a"},
-        {"id": 3, "my_arr1": ['c'],           "other_arr": [1] ,"my_str": "a"},
-        {"id": 4, "my_arr1": None,            "other_arr": [1] ,"my_str": "a"},
-        {"id": 5, "my_arr1": None,            "other_arr": [1] ,"my_str": "a"},
-        {"id": 6, "my_arr1": None,            "other_arr": [1] ,"my_str": "a"},
+        {"id": 1, "my_arr1": ["a", "b", "c"], "other_arr": None,"my_str": "a", "complex_arr": [[1], [1]]},
+        {"id": 2, "my_arr1": None,            "other_arr": [1] ,"my_str": "a", "complex_arr": None},
+        {"id": 3, "my_arr1": ['c'],           "other_arr": [1] ,"my_str": "a", "complex_arr": None},
+        {"id": 4, "my_arr1": None,            "other_arr": [1] ,"my_str": "a", "complex_arr": [[1]]},
+        {"id": 5, "my_arr1": None,            "other_arr": [1] ,"my_str": "a", "complex_arr": [[1],[1]]},
+        {"id": 6, "my_arr1": None,            "other_arr": [1] ,"my_str": "a", "complex_arr": [[1],[1]]},
 
     ]
+    # fmt: on
 
     df_expected = pd.DataFrame(df_expected)
 
-    pd.testing.assert_frame_equal(df_result,df_expected)
-
+    pd.testing.assert_frame_equal(df_result, df_expected)


### PR DESCRIPTION
The `fix_zero_length_arrays` function has data type problem when arrays are non strings

 "cannot resolve 'trim(namedlambdavariable())' due to data type mismatch: argument 1 requires string type, however, 'namedlambdavariable()' is of struct<lat:double,long:double>